### PR TITLE
document the included SDK version

### DIFF
--- a/spinnakerSupport/README.md
+++ b/spinnakerSupport/README.md
@@ -1,0 +1,1 @@
+Spinnaker SDK 1.20.0.14. Make sure install the same version on the target PC.


### PR DESCRIPTION
The R2-1 release notes mentions problematic mismatching SDK version in the target PC.

It would be still good to indicate the SDK version included. The one from [FLR](https://meta.box.lenovo.com/v/link/view/a1995795ffba47dbbe45771477319cc3) is way newer.
And the even older ones are not kept there.